### PR TITLE
SearchView Error handling

### DIFF
--- a/HolidayMakerClient/HolidayMakerClient/View/SearchView.xaml
+++ b/HolidayMakerClient/HolidayMakerClient/View/SearchView.xaml
@@ -111,7 +111,7 @@
                 PlaceholderText="Välj datum"
                 FirstDayOfWeek="Monday"
                 DateFormat="{}{day.integer} {month.full} {year.full}"
-                CalendarViewDayItemChanging="datePicker_StartDate_CalendarViewDayItemChanging"
+                CalendarViewDayItemChanging="DatePickers_CalendarViewDayItemChanging"
                 />
             <CalendarDatePicker
                 Grid.Column="2"
@@ -120,7 +120,7 @@
                 PlaceholderText="Välj datum"
                 FirstDayOfWeek="Monday"
                 DateFormat="{}{day.integer} {month.full} {year.full}"
-                CalendarViewDayItemChanging="datePicker_StartDate_CalendarViewDayItemChanging"
+                CalendarViewDayItemChanging="DatePickers_CalendarViewDayItemChanging"
                 />
             <ComboBox
                 x:Name="comboBox_NumberOfGuests"


### PR DESCRIPTION
- The user has to input a searchterm
- The dates cannot be the same
- The End date cannot be before the Start date
- When navigating to the selected living view, the last searched dates are the ones used.
This means that you can't change the date after hitting 'search' and have it register if you don't hit 'search' again