### PR TITLE
ActiveUser name on MyPage

### DIFF
--- a/HolidayMakerClient/HolidayMakerClient/View/MyPageView.xaml.cs
+++ b/HolidayMakerClient/HolidayMakerClient/View/MyPageView.xaml.cs
@@ -38,6 +38,7 @@ namespace HolidayMakerClient.View
         public MyPageView()
         {
             this.InitializeComponent();
+            loginViewModel = LoginViewModel.Instance;
             this.DataContext = myPageViewModel;
         }
         #endregion
@@ -57,7 +58,7 @@ namespace HolidayMakerClient.View
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
 
-            loginViewModel = LoginViewModel.Instance;
+            
         }
 
 


### PR DESCRIPTION
Moved the ActiveUser initialization from Page_Loaded to the constructor so the active user name will show at the top right corner of MyPage